### PR TITLE
Fixed path in generated links to cplaceJS API classes

### DIFF
--- a/src/builder/BuilderUtils.ts
+++ b/src/builder/BuilderUtils.ts
@@ -33,9 +33,10 @@ export function groupData(templateData: Array<any>): IEntityGroups {
 }
 
 export function generateLinks(pluginShortName: string, groups: IEntityGroups) {
-    groups.clazz.forEach(value => entityToLink.set(value, `/${linkBase}/${pluginShortName}/s${value.toLowerCase()}`));
+    let pluginShortNameAdapted = pluginShortName.replace(/[.]/g, '-').toLowerCase();
+    groups.clazz.forEach(value => entityToLink.set(value, `/${linkBase}/${pluginShortNameAdapted}/${value.toLowerCase()}`));
     groups.typedef.forEach(value => {
-        entityToLink.set(value, `/${linkBase}/${pluginShortName}/${typeDefSlug}#${value.toLocaleLowerCase()}`);
+        entityToLink.set(value, `/${linkBase}/${pluginShortNameAdapted}/${typeDefSlug}#${value.toLocaleLowerCase()}`);
     });
     // console.log(entityToLink.forEach((val, key) => console.log(key, val)));
 }


### PR DESCRIPTION
Notes:
- This will just replace the dots in plugin name with dashes in the generated link URLs
- Generated .md contains links which look ok.
- Copying the generated files manully to cplace-docs-lowcode repo and running `hugo -D serve` serves pages with correct links

But:
- I wasn't able to get the complete mechanism of building hugo docs from scratch to run locally, so could not test it. I locally compile and installed the cplace-jsdocs repo and executed the `cplacejs-docs` on cmdline to generate .md files from the API.
- I have no idea if simply changing the typescript code in this repo is sufficient to make the build process use this code or if we have to somehow publish a new cplacejs-docs version (and reference this in `docs` repo.). I simply lack the knowledge of npm and gulp build processes 😢 

So it would be great if someone with a clue could take a look at this PR.